### PR TITLE
feat(mic1): add orchestration, microprogram loader and logger #9

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod cpu;
 pub mod instruction_register;
 pub mod loader;
 pub mod logger;
+pub mod mic1;
 pub mod register;
 pub mod microinstruction;
 

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -4,7 +4,7 @@ use std::{path::Path, str::FromStr};
 #[derive(Debug)]
 pub enum LoaderError {
     Io(std::io::Error),
-    Line { line: usize, message: AluParseError },
+    Line { line: usize, message: String },
 }
 
 impl From<std::io::Error> for LoaderError {
@@ -40,13 +40,26 @@ pub fn load_program(path: impl AsRef<Path>) -> Result<Vec<AluInstruction>, Loade
             continue;
         }
 
-        let instr = AluInstruction::from_str(line).map_err(|message| LoaderError::Line {
+        let instr = AluInstruction::from_str(line).map_err(|e: AluParseError| LoaderError::Line {
             line: idx + 1,
-            message,
+            message: e.to_string(),
         })?;
         program.push(instr);
     }
 
+    Ok(program)
+}
+
+pub fn load_microprogram(path: impl AsRef<std::path::Path>) -> Result<Vec<crate::microinstruction::MicroInstruction>, LoaderError> {
+    let contents = std::fs::read_to_string(path.as_ref())?;
+    let mut program = Vec::new();
+    for (idx, raw_line) in contents.lines().enumerate() {
+        let line = raw_line.trim_end();
+        if line.is_empty() { continue; }
+        let instr = line.parse::<crate::microinstruction::MicroInstruction>()
+            .map_err(|e| LoaderError::Line { line: idx + 1, message: e.to_string() })?;
+        program.push(instr);
+    }
     Ok(program)
 }
 

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,4 +1,6 @@
 use crate::cpu::ExecutionLog;
+use crate::microinstruction::MicroInstruction;
+use crate::register::Registers;
 use std::io::{Result, Write};
 
 /// Logger responsável por escrever a execução do programa em qualquer saída
@@ -64,6 +66,68 @@ impl<W: Write> Logger<W> {
     /// Mensagem de erro para combinação inválida de sinais de deslocamento (`SLL8` e `SRA1`).
     pub fn log_invalid(&mut self) -> Result<()> {
         writeln!(self.writer, "> Error, invalid control signals.")?;
+        Ok(())
+    }
+
+    pub fn log_mic1_start(&mut self, regs: &Registers) -> std::io::Result<()> {
+        writeln!(self.writer, "Start of Mic-1 Program")?;
+        writeln!(self.writer)?;
+        writeln!(self.writer, "Initial Registers:")?;
+        self.write_registers(regs)?;
+        writeln!(self.writer)?;
+        Ok(())
+    }
+
+    pub fn log_mic1_cycle(
+        &mut self,
+        cycle: usize,
+        instr: &MicroInstruction,
+        b_name: &str,
+        c_names: &[&str],
+        before: &Registers,
+        after: &Registers,
+    ) -> std::io::Result<()> {
+        writeln!(self.writer, "============================================================")?;
+        writeln!(self.writer, "Cycle {cycle}")?;
+        writeln!(self.writer)?;
+        writeln!(self.writer, "IR = {instr}")?;
+        writeln!(self.writer)?;
+        writeln!(self.writer, "B-bus: {b_name}")?;
+        if c_names.is_empty() {
+            writeln!(self.writer, "C-bus: (none)")?;
+        } else {
+            writeln!(self.writer, "C-bus: {}", c_names.join(", "))?;
+        }
+        writeln!(self.writer)?;
+        writeln!(self.writer, "Registers (before):")?;
+        self.write_registers(before)?;
+        writeln!(self.writer)?;
+        writeln!(self.writer, "Registers (after):")?;
+        self.write_registers(after)?;
+        Ok(())
+    }
+
+    pub fn log_mic1_eop(&mut self, cycle: usize) -> std::io::Result<()> {
+        writeln!(self.writer, "============================================================")?;
+        writeln!(self.writer, "Cycle {cycle}")?;
+        writeln!(self.writer)?;
+        writeln!(self.writer, "> End of Program.")?;
+        writeln!(self.writer)?;
+        self.writer.flush()?;
+        Ok(())
+    }
+
+    fn write_registers(&mut self, regs: &Registers) -> std::io::Result<()> {
+        writeln!(self.writer, "  H   = {:032b}", regs.h)?;
+        writeln!(self.writer, "  OPC = {:032b}", regs.opc)?;
+        writeln!(self.writer, "  TOS = {:032b}", regs.tos)?;
+        writeln!(self.writer, "  CPP = {:032b}", regs.cpp)?;
+        writeln!(self.writer, "  LV  = {:032b}", regs.lv)?;
+        writeln!(self.writer, "  SP  = {:032b}", regs.sp)?;
+        writeln!(self.writer, "  MBR = {:08b}", regs.mbr)?;
+        writeln!(self.writer, "  PC  = {:032b}", regs.pc)?;
+        writeln!(self.writer, "  MDR = {:032b}", regs.mdr)?;
+        writeln!(self.writer, "  MAR = {:032b}", regs.mar)?;
         Ok(())
     }
 

--- a/src/mic1.rs
+++ b/src/mic1.rs
@@ -1,0 +1,30 @@
+use crate::{
+    alu::Alu,
+    microinstruction::{c_bus_names, c_bus_write, MicroInstruction},
+    register::Registers,
+};
+
+pub struct Mic1 {
+    pub regs: Registers,
+}
+
+impl Mic1 {
+    pub fn new(regs: Registers) -> Self {
+        Self { regs }
+    }
+
+    pub fn step(
+        &mut self,
+        instr: &MicroInstruction,
+    ) -> (&'static str, Vec<&'static str>, Registers, Registers) {
+        let before = self.regs.clone();
+        let b_name = Registers::b_bus_name(instr.b_sel);
+        let b = self.regs.b_bus_decode(instr.b_sel);
+        let a = self.regs.h;
+        let (_, alu_result) = Alu::execute(a, b, instr.alu);
+        let c_names = c_bus_names(instr.c_sel);
+        c_bus_write(&mut self.regs, instr.c_sel, alu_result.sd);
+        let after = self.regs.clone();
+        (b_name, c_names, before, after)
+    }
+}

--- a/src/register.rs
+++ b/src/register.rs
@@ -14,7 +14,7 @@ use std::path::Path;
 /// | 7        | TOS    | direct             |
 /// | 8        | OPC    | direct             |
 ///
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Registers {
     pub mar: u32,
     pub mdr: u32,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -124,6 +124,43 @@ fn test_etapa2_logger_output_matches_execution() -> Result<(), Box<dyn std::erro
 }
 
 #[test]
+fn test_etapa2_tarefa2_mic1_execution() -> Result<(), Box<dyn std::error::Error>> {
+    use mic_arch::{loader::load_microprogram, mic1::Mic1, register::Registers};
+    use std::path::Path;
+
+    let regs = Registers::load("./tests/data/registradores_etapa2_tarefa2.txt")?;
+    let program = load_microprogram("./tests/data/programa_etapa2_tarefa2.txt")?;
+
+    let mut mic1 = Mic1::new(regs);
+    let mut buf = Cursor::new(Vec::<u8>::new());
+    let mut logger = Logger::new(&mut buf);
+
+    logger.log_mic1_start(&mic1.regs.clone())?;
+
+    for (idx, instr) in program.iter().enumerate() {
+        let (b_name, c_names, before, after) = mic1.step(instr);
+        logger.log_mic1_cycle(idx + 1, instr, b_name, &c_names, &before, &after)?;
+    }
+    logger.log_mic1_eop(program.len() + 1)?;
+
+    let output = String::from_utf8(buf.into_inner())?.replace("\r\n", "\n");
+
+    assert!(output.contains("Start of Mic-1 Program"));
+    assert!(output.contains("End of Program"));
+    assert!(output.contains("B-bus:"));
+    assert!(output.contains("Registers (before):"));
+    assert!(output.contains("Registers (after):"));
+
+    let golden_path = Path::new("./tests/data/saída_etapa2_tarefa2.txt");
+    if golden_path.exists() {
+        let expected = std::fs::read_to_string(golden_path)?.replace("\r\n", "\n");
+        assert_eq!(output, expected);
+    }
+
+    Ok(())
+}
+
+#[test]
 fn test_logger_invalid_cycle_format() -> Result<(), Box<dyn std::error::Error>> {
     use mic_arch::alu::{AluInstruction, AluResult, Inputs};
     use mic_arch::cpu::ExecutionLog;


### PR DESCRIPTION
## What
Implements GitHub issue #9 — wires together the Mic-1 data-path for Etapa 2, Tarefa 2.

## Changes
- **register.rs** — added `Clone` to `Registers` (required for before/after snapshots)
- **loader.rs** — changed `LoaderError::Line.message` to `String`; added `load_microprogram`
- **mic1.rs** — new file: `Mic1` struct with `step` (B-bus decode → ALU → C-bus write-back)
- **logger.rs** — added `log_mic1_start`, `log_mic1_cycle`, `log_mic1_eop`, `write_registers`
- **lib.rs** — added `pub mod mic1`
- **integration_test.rs** — added `test_etapa2_tarefa2_mic1_execution`

## Testing
`cargo check` passes cleanly.

Closes #9